### PR TITLE
Fix screenshot step input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2024-03-04
+### Fixed
+* Remove input validation in screenshot step, so it automatically uses the validation method of the `HttpBase` step, so it also allows to use the `useInputKeyAs...` methods.
+
 ## [1.2.0] - 2024-02-26
 ### Added
 * Option to wait a certain amount of time after loading a page, before taking the screenshot (`Screenshot::waitAfterPageLoaded()`).

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": "^8.1",
-        "crwlr/crawler": "^1.6.1"
+        "crwlr/crawler": "^1.7.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.19",

--- a/src/Steps/Screenshot.php
+++ b/src/Steps/Screenshot.php
@@ -111,11 +111,6 @@ class Screenshot extends BrowserBaseStep
         return null;
     }
 
-    protected function validateAndSanitizeInput(mixed $input): mixed
-    {
-        return $this->validateAndSanitizeToUriInterface($input);
-    }
-
     protected function fullStorePathFromResponse(RespondedRequest $response): string
     {
         $fileName = $response->cacheKey() . '-' . time() . '.png';

--- a/tests/_Integration/ScreenshotTest.php
+++ b/tests/_Integration/ScreenshotTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Crwlr\Crawler\Steps\Json;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\CrawlerExtBrowser\Aggregates\RespondedRequestWithScreenshot;
 use Crwlr\CrawlerExtBrowser\Steps\GetColors;
@@ -136,4 +137,21 @@ it('waits the defined amount of time before taking a screenshot', function () {
         ->toBe(255)
         ->and($colors[1]['percentage'])
         ->toBeLessThanOrEqual(3.0);
+});
+
+it('sends custom headers', function () {
+    $crawler = helper_getFastCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/print-headers')
+        ->addStep(
+            Screenshot::loadAndTake(helper_testFilePath(), ['x-custom-header' => 'foo'])
+        )
+        ->addStep(Json::get(['headers' => '*'])->addToResult());
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0]->get('headers'))->toBeArray()
+        ->and($results[0]->get('headers')['x-custom-header'])->toBe('foo');
 });

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -9,3 +9,7 @@ if ($route === '/screenshot') {
 if ($route === '/screenshot-wait') {
     return include(__DIR__ . '/_Server/ScreenshotWait.php');
 }
+
+if ($route === '/print-headers') {
+    return include(__DIR__ . '/_Server/PrintHeaders.php');
+}

--- a/tests/_Integration/_Server/PrintHeaders.php
+++ b/tests/_Integration/_Server/PrintHeaders.php
@@ -1,0 +1,5 @@
+<?php
+
+header('Content-Type: application/json');
+
+echo json_encode(getallheaders());


### PR DESCRIPTION
Remove input validation in screenshot step, so it automatically uses the validation method of the `HttpBase` step, so it also allows to use the `useInputKeyAs...` methods.