### PR TITLE
Add timeout feature in Screenshot step and merge crwl-ext-browser package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2024-06-17
+## [1.3.0] - 2024-06-18
 ### Added
 * Merge things from the `crwlr/crwl-ext-browser` package to this one, because they are too tightly coupled. The other package will be abandoned.
 * Add `timeout` config param to `ScreenshotBuilder`, therefore also require `crwlr/crawler` v1.9.0 (or greater), with the new functionality to configure timeouts for the headless browser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2024-06-17
+### Added
+* Merge things from the `crwlr/crwl-ext-browser` package to this one, because they are too tightly coupled. The other package will be abandoned.
+* Add `timeout` config param to `ScreenshotBuilder`, therefore also require `crwlr/crawler` v1.9.0 (or greater), with the new functionality to configure timeouts for the headless browser.
+
 ## [1.2.1] - 2024-03-04
 ### Fixed
 * Remove input validation in screenshot step, so it automatically uses the validation method of the `HttpBase` step, so it also allows to use the `useInputKeyAs...` methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Merge things from the `crwlr/crwl-ext-browser` package to this one, because they are too tightly coupled. The other package will be abandoned.
 * Add `timeout` config param to `ScreenshotBuilder`, therefore also require `crwlr/crawler` v1.9.0 (or greater), with the new functionality to configure timeouts for the headless browser.
 
+### Fixed
+* Prepare for `crwlr/crawler` v2.0.
+
 ## [1.2.1] - 2024-03-04
 ### Fixed
 * Remove input validation in screenshot step, so it automatically uses the validation method of the `HttpBase` step, so it also allows to use the `useInputKeyAs...` methods.

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require": {
         "php": "^8.1",
-        "crwlr/crawler": "^1.9",
+        "crwlr/crawler": "^1.9.2",
         "crwlr/crwl-extension-utils": "^2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,20 @@
     },
     "require": {
         "php": "^8.1",
-        "crwlr/crawler": "^1.7.0"
+        "crwlr/crawler": "^1.9",
+        "crwlr/crwl-extension-utils": "^2.3"
     },
     "require-dev": {
         "pestphp/pest": "^2.19",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^3.30"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Crwlr\\CrawlerExtBrowser\\ServiceProvider"
+            ]
+        }
     },
     "suggest": {
         "ext-gd": "*"

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Crwlr\CrawlerExtBrowser;
+
+use Crwlr\CrawlerExtBrowser\StepBuilders\GetColorsBuilder;
+use Crwlr\CrawlerExtBrowser\StepBuilders\ScreenshotBuilder;
+use Crwlr\CrwlExtensionUtils\Exceptions\DuplicateExtensionPackageException;
+use Crwlr\CrwlExtensionUtils\Exceptions\DuplicateStepIdException;
+use Crwlr\CrwlExtensionUtils\Exceptions\InvalidStepException;
+use Crwlr\CrwlExtensionUtils\ExtensionPackageManager;
+use Illuminate\Contracts\Container\BindingResolutionException;
+
+class ServiceProvider extends \Illuminate\Support\ServiceProvider
+{
+    /**
+     * @throws DuplicateExtensionPackageException
+     * @throws DuplicateStepIdException
+     * @throws InvalidStepException
+     * @throws BindingResolutionException
+     */
+    public function boot(): void
+    {
+        $this->app->make(ExtensionPackageManager::class)
+            ->registerPackage('crwlr/crawler-ext-browser')
+            ->registerStep(ScreenshotBuilder::class)
+            ->registerStep(GetColorsBuilder::class);
+    }
+}

--- a/src/StepBuilders/GetColorsBuilder.php
+++ b/src/StepBuilders/GetColorsBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Crwlr\CrawlerExtBrowser\StepBuilders;
+
+use Crwlr\Crawler\Steps\StepInterface;
+use Crwlr\CrawlerExtBrowser\Steps\GetColors;
+use Crwlr\CrwlExtensionUtils\ConfigParam;
+use Crwlr\CrwlExtensionUtils\StepBuilder;
+use Exception;
+
+class GetColorsBuilder extends StepBuilder
+{
+    public function stepId(): string
+    {
+        return 'browser.getColorsFromImage';
+    }
+
+    public function label(): string
+    {
+        return 'Get the most used colors from an image (e.g. screenshot).';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function configToStep(array $stepConfig): StepInterface
+    {
+        $step = GetColors::fromImage();
+
+        $onlyAbovePercentage = $this->getValueFromConfigArray('onlyAbovePercentage', $stepConfig);
+
+        if ($onlyAbovePercentage !== null && $onlyAbovePercentage > 0.0) {
+            $step->onlyAbovePercentageOfImage($onlyAbovePercentage);
+        }
+
+        return $step;
+    }
+
+    public function configParams(): array
+    {
+        return [
+            ConfigParam::float('onlyAbovePercentage')
+                ->inputLabel('Only Above Percentage')
+                ->description('Get only colors that make up at least a certain percentage of the image.'),
+        ];
+    }
+}

--- a/src/StepBuilders/ScreenshotBuilder.php
+++ b/src/StepBuilders/ScreenshotBuilder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Crwlr\CrawlerExtBrowser\StepBuilders;
+
+use Crwlr\Crawler\Steps\StepInterface;
+use Crwlr\CrawlerExtBrowser\Steps\Screenshot;
+use Crwlr\CrwlExtensionUtils\ConfigParam;
+use Crwlr\CrwlExtensionUtils\StepBuilder;
+use Exception;
+
+class ScreenshotBuilder extends StepBuilder
+{
+    public function stepId(): string
+    {
+        return 'browser.screenshot';
+    }
+
+    public function label(): string
+    {
+        return 'Load a page in the browser and take a screenshot.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function configToStep(array $stepConfig): StepInterface
+    {
+        if (empty($this->fileStoragePath)) {
+            throw new Exception('No file storage path defined.');
+        }
+
+        $step = Screenshot::loadAndTake($this->fileStoragePath);
+
+        $waitAfterPageLoaded = $this->getValueFromConfigArray('waitAfterPageLoaded', $stepConfig);
+
+        if ($waitAfterPageLoaded !== null && $waitAfterPageLoaded > 0.0) {
+            $step->waitAfterPageLoaded($waitAfterPageLoaded);
+        }
+
+        $timeout = $this->getValueFromConfigArray('timeout', $stepConfig);
+
+        if (is_float($timeout)) {
+            $step->timeout($timeout);
+        }
+
+        return $step;
+    }
+
+    public function configParams(): array
+    {
+        return [
+            ConfigParam::float('waitAfterPageLoaded')
+                ->inputLabel('Wait X seconds')
+                ->description('Wait X seconds after the page is fully loaded, before taking the screenshot.'),
+            ConfigParam::float('timeout')
+                ->inputLabel('Timeout')
+                ->description('Timeout in seconds. After waiting for this amount of time, a request will be cancelled.')
+                ->default(30.0),
+        ];
+    }
+}

--- a/src/Steps/GetColors.php
+++ b/src/Steps/GetColors.php
@@ -3,6 +3,7 @@
 namespace Crwlr\CrawlerExtBrowser\Steps;
 
 use Crwlr\Crawler\Steps\Step;
+use Crwlr\Crawler\Steps\StepOutputType;
 use Crwlr\CrawlerExtBrowser\Aggregates\RespondedRequestWithScreenshot;
 use Crwlr\CrawlerExtBrowser\Utils\ImageColors;
 use Exception;
@@ -22,6 +23,11 @@ class GetColors extends Step
         $this->onlyAbovePercentageOfImage = $percentage;
 
         return $this;
+    }
+
+    public function outputType(): StepOutputType
+    {
+        return StepOutputType::AssociativeArrayOrObject;
     }
 
     /**

--- a/src/Steps/Screenshot.php
+++ b/src/Steps/Screenshot.php
@@ -69,7 +69,6 @@ class Screenshot extends BrowserBaseStep
     protected function invoke(mixed $input): Generator
     {
         $this->switchBefore();
-        $this->_switchLoaderBefore();
 
         $input = !is_array($input) ? [$input] : $input;
 
@@ -99,7 +98,7 @@ class Screenshot extends BrowserBaseStep
 
         $this->resetInputRequestParams();
 
-        $this->_switchLoaderAfterwards();
+        $this->switchAfterwards();
     }
 
     protected function switchBefore(): void
@@ -121,6 +120,8 @@ class Screenshot extends BrowserBaseStep
 
         if ($this->_previousBrowserTimeoutValue !== null) {
             $this->loader->browserHelper()->setTimeout($this->_previousBrowserTimeoutValue);
+
+            $this->_previousBrowserTimeoutValue = null;
         }
     }
 

--- a/src/Steps/Screenshot.php
+++ b/src/Steps/Screenshot.php
@@ -3,8 +3,8 @@
 namespace Crwlr\CrawlerExtBrowser\Steps;
 
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\StepOutputType;
 use Crwlr\CrawlerExtBrowser\Aggregates\RespondedRequestWithScreenshot;
-use Crwlr\Utils\Microseconds;
 use Exception;
 use Generator;
 use HeadlessChromium\Exception\CommunicationException;
@@ -54,6 +54,11 @@ class Screenshot extends BrowserBaseStep
         $this->browserTimeout = (int) ($seconds * 1000);
 
         return $this;
+    }
+
+    public function outputType(): StepOutputType
+    {
+        return StepOutputType::AssociativeArrayOrObject;
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,7 +21,7 @@ uses()
     ->beforeEach(function () {
         if (!isset(TestServerProcess::$process)) {
             TestServerProcess::$process = Process::fromShellCommandline(
-                'php -S localhost:8000 ' . __DIR__ . '/_Integration/Server.php'
+                'php -S localhost:8000 ' . __DIR__ . '/_Integration/Server.php',
             );
 
             TestServerProcess::$process->start();
@@ -54,7 +54,7 @@ function helper_getFastCrawler(): HttpCrawler
         {
             return new UserAgent(
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) ' .
-                'Chrome/120.0.0.0 Safari/537.36'
+                'Chrome/120.0.0.0 Safari/537.36',
             );
         }
 

--- a/tests/_Integration/GetColorsTest.php
+++ b/tests/_Integration/GetColorsTest.php
@@ -48,7 +48,7 @@ it('gets the colors from an image', function () {
         ->input(['screenshotPath' => helper_testFilePath('demo-screenshot.png')])
         ->addStep(
             GetColors::fromImage()
-                ->onlyAbovePercentageOfImage(0.4)
+                ->onlyAbovePercentageOfImage(0.4),
         );
 
     $results = iterator_to_array($crawler->run());
@@ -73,7 +73,7 @@ it('does not run out of memory with a very colorful image and 100MB of memory', 
 
     $crawler
         ->input(['screenshotPath' => helper_testFilePath('demo-screenshot2.png')])
-        ->addStep(GetColors::fromImage()->addToResult());
+        ->addStep(GetColors::fromImage());
 
     $results = iterator_to_array($crawler->run());
 
@@ -93,8 +93,7 @@ it('gets colors that make up at least a certain percentage when onlyAbovePercent
         ->input(['screenshotPath' => helper_testFilePath('demo-screenshot2.png')])
         ->addStep(
             GetColors::fromImage()
-                ->onlyAbovePercentageOfImage(0.1)
-                ->addToResult()
+                ->onlyAbovePercentageOfImage(0.1),
         );
 
     $results = iterator_to_array($crawler->run());

--- a/tests/_Integration/ScreenshotTest.php
+++ b/tests/_Integration/ScreenshotTest.php
@@ -159,21 +159,22 @@ it('sends custom headers', function () {
         ->and($results[0]->get('headers')['x-custom-header'])->toBe('foo');
 });
 
-it('uses the defined timeout', function () {
+it('uses the defined timeout and changes it back after execution', function () {
     $crawler = helper_getFastCrawler();
+
+    $defaultTimeout = $crawler->getLoader()->browserHelper()->getTimeout();
+
+    $step = Screenshot::loadAndTake(helper_testFilePath())->timeout(0.5);
 
     $crawler
         ->input('http://localhost:8000/timeout')
-        ->addStep(
-            Screenshot::loadAndTake(helper_testFilePath())->timeout(0.5),
-        );
+        ->addStep($step);
 
     $results = iterator_to_array($crawler->run());
 
     $output = $this->getActualOutputForAssertion();
 
-    error_log(var_export($output, true));
-
     expect($results)->toHaveCount(0)
-        ->and($output)->toContain('Failed to load http://localhost:8000/timeout: Operation timed out after 500ms');
+        ->and($output)->toContain('Failed to load http://localhost:8000/timeout: Operation timed out after 500ms')
+        ->and($crawler->getLoader()->browserHelper()->getTimeout())->toBe($defaultTimeout);
 });

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -13,3 +13,11 @@ if ($route === '/screenshot-wait') {
 if ($route === '/print-headers') {
     return include(__DIR__ . '/_Server/PrintHeaders.php');
 }
+
+if ($route === '/timeout') {
+    sleep(1);
+
+    echo 'Hi';
+
+    return;
+}


### PR DESCRIPTION
* Merge things from the `crwlr/crwl-ext-browser` package to this one, because they are too tightly coupled. The other package will be abandoned.
* Add `timeout` config param to `ScreenshotBuilder`, therefore also require `crwlr/crawler` v1.9.0 (or greater), with the new functionality to configure timeouts for the headless browser.
* Make improvements for `crwlr/crawler` v2.0.