### PR TITLE
Add Screenshot::take() step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.4.0] - 2024-07-08
+### Added
+* `Screenshot::take()` in addition to `Screenshot::loadAndTake()`, allowing to take a screenshot of an already opened page, in a separate step. This way you can even add this step after an `Http::crawl()` step and get screenshots of all the crawled pages.
+
 ### Fixed
 * Change calls to `HttpLoader::browserHelper()` to `HttpLoader::browser()` and require `crwlr/crawler` with constraint `^1.9.3` to make sure the method exists.
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,7 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        - tests/_Integration/_Server
 #    ignoreErrors:
 #        - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -21,3 +21,15 @@ if ($route === '/timeout') {
 
     return;
 }
+
+if (str_starts_with($route, '/crawl-screenshot')) {
+    $split = explode('/crawl-screenshot/', $route);
+
+    if (count($split) === 1) {
+        $page = '0';
+    } else {
+        $page = $split[1];
+    }
+
+    return include(__DIR__ . '/_Server/CrawlScreenshot.php');
+}

--- a/tests/_Integration/_Server/CrawlScreenshot.php
+++ b/tests/_Integration/_Server/CrawlScreenshot.php
@@ -1,0 +1,13 @@
+<!Doctype html>
+<html lang="en">
+<head>
+    <title>Another example page for taking a screenshot!</title>
+</head>
+<body style="background-color: cadetblue;">
+<h1>Hi On Page <?=$page?></h1>
+
+<?php if ($page === '0') { ?>
+<a href="/crawl-screenshot/1">Link to another page</a>
+<?php } ?>
+</body>
+</html>


### PR DESCRIPTION
Add `Screenshot::take()` in addition to `Screenshot::loadAndTake()`, allowing to take a screenshot of an already opened page, in a separate step. This way you can even add this step after an `Http::crawl()` step and get screenshots of all the crawled pages.

Also exclude tests/_Integration/_Server from phpstan.