### PR TITLE
InitSession step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-12-21
+### Added
+* The new `InitSession` step. It initiates a session by making a headless browser request to a URL. After completing the request, it yields the same input URL as output, allowing it to be subsequently loaded using a simple HTTP client with session cookie headers obtained from the initial browser request.
+
 ## [2.0.1] - 2024-12-09
 ### Fixed
 * Support crwlr/crawler v3.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Crwlr\CrawlerExtBrowser;
 
 use Crwlr\CrawlerExtBrowser\StepBuilders\GetColorsBuilder;
+use Crwlr\CrawlerExtBrowser\StepBuilders\InitSessionBuilder;
 use Crwlr\CrawlerExtBrowser\StepBuilders\ScreenshotBuilder;
 use Crwlr\CrawlerExtBrowser\StepBuilders\TakeScreenshotBuilder;
 use Crwlr\CrwlExtensionUtils\Exceptions\DuplicateExtensionPackageException;
@@ -25,6 +26,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             ->registerPackage('crwlr/crawler-ext-browser')
             ->registerStep(ScreenshotBuilder::class)
             ->registerStep(TakeScreenshotBuilder::class)
-            ->registerStep(GetColorsBuilder::class);
+            ->registerStep(GetColorsBuilder::class)
+            ->registerStep(InitSessionBuilder::class);
     }
 }

--- a/src/StepBuilders/InitSessionBuilder.php
+++ b/src/StepBuilders/InitSessionBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Crwlr\CrawlerExtBrowser\StepBuilders;
+
+use Crwlr\Crawler\Steps\StepInterface;
+use Crwlr\Crawler\Steps\StepOutputType;
+use Crwlr\CrawlerExtBrowser\Steps\InitSession;
+use Crwlr\CrwlExtensionUtils\StepBuilder;
+use Exception;
+
+class InitSessionBuilder extends StepBuilder
+{
+    public function stepId(): string
+    {
+        return 'browser.initSession';
+    }
+
+    public function label(): string
+    {
+        return 'Initiates a session by making a headless browser request to a URL. After completing the request, ' .
+            'it yields the same input URL as output, allowing it to be subsequently loaded using a simple HTTP ' .
+            'client with session cookie headers obtained from the initial browser request.';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function configToStep(array $stepConfig): StepInterface
+    {
+        return new InitSession();
+    }
+
+    public function configParams(): array
+    {
+        return [];
+    }
+
+    public function outputType(): StepOutputType
+    {
+        return StepOutputType::Scalar;
+    }
+
+    public function isLoadingStep(): bool
+    {
+        return true;
+    }
+}

--- a/src/Steps/InitSession.php
+++ b/src/Steps/InitSession.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Crwlr\CrawlerExtBrowser\Steps;
+
+use Exception;
+use Generator;
+
+/**
+ * This step performs a request, only to initiate a session with the headless browser.
+ * After loading the input URL, it simply returns the same URL as output, effectively forwarding it to
+ * the next step — such as an HTTP loading step that uses the HTTP (guzzle) client.
+ */
+
+class InitSession extends BrowserBaseStep
+{
+    /**
+     * @throws Exception
+     */
+    protected function invoke(mixed $input): Generator
+    {
+        $this->_switchLoaderBefore();
+
+        $this->getResponseFromInputUri($input);
+
+        $this->_switchLoaderAfterwards();
+
+        yield $input;
+    }
+}

--- a/tests/_Integration/InitSessionTest.php
+++ b/tests/_Integration/InitSessionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\CrawlerExtBrowser\Steps\InitSession;
+
+it(
+    'initiates a session via a request performed by a headless browser, yields the input URL ' .
+    'and session cookies are used by a following non browser loading step',
+    function () {
+        $crawler = helper_getFastCrawler();
+
+        $crawler
+            ->input('http://localhost:8000/init_session')
+            ->addStep(new InitSession())
+            ->addStep(Http::get()->keep('body'));
+
+        $results = iterator_to_array($crawler->run());
+
+        expect($results)->toHaveCount(1);
+
+        $response = $results[0]->get('body');
+
+        expect($response)->toBe('foo');
+    },
+);

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -33,3 +33,19 @@ if (str_starts_with($route, '/crawl-screenshot')) {
 
     return include(__DIR__ . '/_Server/CrawlScreenshot.php');
 }
+
+if (str_starts_with($route, '/init_session')) {
+    $cookie = $_COOKIE['session'] ?? null;
+
+    if ($cookie) {
+        return include(__DIR__ . '/_Server/PrintCookie.php');
+    }
+
+    $redirectParam = $_GET['redirect'] ?? null;
+
+    if (!$redirectParam) {
+        http_response_code(403);
+    }
+
+    return include(__DIR__ . '/_Server/InitSessionRedirect.php');
+}

--- a/tests/_Integration/_Server/InitSessionRedirect.php
+++ b/tests/_Integration/_Server/InitSessionRedirect.php
@@ -1,0 +1,17 @@
+<!Doctype html>
+<html lang="en">
+<head>
+    <?php if ($redirectParam) { ?>
+        <title>Welcome!</title>
+    <?php } else { ?>
+        <title>Forbidden!</title>
+    <?php } ?>
+</head>
+<body>
+<?php if (!$redirectParam) { ?>
+    <script> window.location.href = 'http://localhost:8000/init_session?redirect=1'; </script>
+<?php } else { ?>
+    <script> document.cookie = "session=foo"; </script>
+<?php } ?>
+</body>
+</html>

--- a/tests/_Integration/_Server/PrintCookie.php
+++ b/tests/_Integration/_Server/PrintCookie.php
@@ -1,0 +1,3 @@
+<?php
+
+echo $_COOKIE['session'] ?? '';


### PR DESCRIPTION
The new `InitSession` step. It initiates a session by making a headless browser request to a URL. After completing the request, it yields the same input URL as output, allowing it to be subsequently loaded using a simple HTTP client with session cookie headers obtained from the initial browser request.